### PR TITLE
fix(ISP-194): AWS-S3-Object-Versioning-is-disabled

### DIFF
--- a/src/main/resources/content/cft/AWS-S3-Object-Versioning-is-disabled.json
+++ b/src/main/resources/content/cft/AWS-S3-Object-Versioning-is-disabled.json
@@ -1,6 +1,6 @@
 {
   "severity": "medium",
-  "rule": "$.Resources[*].Type contains AWS::S3::Bucket and ($.Resources.*[?(@.Type=='AWS::S3::Bucket')].Properties.VersioningConfiguration does not exist or ($.Resources[?(@.Type=='AWS::S3::Bucket')].Properties.VersioningConfiguration exists and $.Resources.*[?(@.Type=='AWS::S3::Bucket')].Properties.VersioningConfiguration.Status contains Suspended))",
+  "rule": "$.Resources.*[?(@.Type=='AWS::S3::Bucket')].Properties.VersioningConfiguration does not exist or ($.Resources[?(@.Type=='AWS::S3::Bucket')].Properties.VersioningConfiguration exists and $.Resources.*[?(@.Type=='AWS::S3::Bucket')].Properties.VersioningConfiguration.Status contains Suspended)",
   "id": "8ec3f878-0f5e-4782-b4cd-98018b217be5",
   "enabled": true,
   "resourceType": "s3",

--- a/src/main/resources/content/cft/AWS-S3-Object-Versioning-is-disabled.json
+++ b/src/main/resources/content/cft/AWS-S3-Object-Versioning-is-disabled.json
@@ -1,6 +1,6 @@
 {
   "severity": "medium",
-  "rule": "$.Resources.[*].Type contains AWS::S3::Bucket and ($.Resources.[*].Properties.VersioningConfiguration does not exist or ($.Resources.[*].Properties.VersioningConfiguration exists and $.Resources.[*].Properties.VersioningConfiguration.Status contains Suspended))",
+  "rule": "$.Resources[*].Type contains AWS::S3::Bucket and ($.Resources.*[?(@.Type=='AWS::S3::Bucket')].Properties.VersioningConfiguration does not exist or ($.Resources[?(@.Type=='AWS::S3::Bucket')].Properties.VersioningConfiguration exists and $.Resources.*[?(@.Type=='AWS::S3::Bucket')].Properties.VersioningConfiguration.Status contains Suspended))",
   "id": "8ec3f878-0f5e-4782-b4cd-98018b217be5",
   "enabled": true,
   "resourceType": "s3",

--- a/src/main/resources/content/cft/AWS-S3-Object-Versioning-is-disabled.json
+++ b/src/main/resources/content/cft/AWS-S3-Object-Versioning-is-disabled.json
@@ -1,1 +1,8 @@
-{"severity":"medium","rule":"$.Resources.[*].Type contains AWS::S3::Bucket and ($.Resources.[*].Properties.VersioningConfiguration does not exist or ($.Resources.[*].Properties.VersioningConfiguration exists and $.Resources.[*].Properties.VersioningConfiguration.Status does not equal Enabled))","id":"8ec3f878-0f5e-4782-b4cd-98018b217be5","enabled":true,"resourceType":"s3","policy":"AWS S3 Object Versioning is disabled"}
+{
+  "severity": "medium",
+  "rule": "$.Resources.[*].Type contains AWS::S3::Bucket and ($.Resources.[*].Properties.VersioningConfiguration does not exist or ($.Resources.[*].Properties.VersioningConfiguration exists and $.Resources.[*].Properties.VersioningConfiguration.Status contains Suspended))",
+  "id": "8ec3f878-0f5e-4782-b4cd-98018b217be5",
+  "enabled": true,
+  "resourceType": "s3",
+  "policy": "AWS S3 Object Versioning is disabled"
+}

--- a/src/test/resources/cft/AWS-S3-Object-Versioning-is-disabled/AWS-S3-Object-Versioning-is-disabled-negative.json
+++ b/src/test/resources/cft/AWS-S3-Object-Versioning-is-disabled/AWS-S3-Object-Versioning-is-disabled-negative.json
@@ -1,0 +1,210 @@
+{
+  "Resources": {
+    "RecordServiceS3Bucket": {
+      "Type": "AWS::S3::Bucket",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "ReplicationConfiguration": {
+          "Role": {
+            "Fn::GetAtt": [
+              "WorkItemBucketBackupRole",
+              "Arn"
+            ]
+          },
+          "Rules": [
+            {
+              "Destination": {
+                "Bucket": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:s3:::",
+                      {
+                        "Fn::Join": [
+                          "-",
+                          [
+                            {
+                              "Ref": "AWS::Region"
+                            },
+                            {
+                              "Ref": "AWS::StackName"
+                            },
+                            "replicationbucket"
+                          ]
+                        ]
+                      }
+                    ]
+                  ]
+                },
+                "StorageClass": "STANDARD"
+              },
+              "Id": "Backup",
+              "Prefix": "",
+              "Status": "Enabled"
+            }
+          ]
+        },
+        "VersioningConfiguration": {
+          "Status": "Enabled"
+        }
+      }
+    },
+    "RecordServiceS3Bucket2": {
+      "Type": "AWS::S3::Bucket",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "ReplicationConfiguration": {
+          "Role": {
+            "Fn::GetAtt": [
+              "WorkItemBucketBackupRole",
+              "Arn"
+            ]
+          },
+          "Rules": [
+            {
+              "Destination": {
+                "Bucket": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:s3:::",
+                      {
+                        "Fn::Join": [
+                          "-",
+                          [
+                            {
+                              "Ref": "AWS::Region"
+                            },
+                            {
+                              "Ref": "AWS::StackName"
+                            },
+                            "replicationbucket"
+                          ]
+                        ]
+                      }
+                    ]
+                  ]
+                },
+                "StorageClass": "STANDARD"
+              },
+              "Id": "Backup",
+              "Prefix": "",
+              "Status": "Enabled"
+            }
+          ]
+        },
+        "VersioningConfiguration": {
+          "Status": "Enabled"
+        }
+      }
+    },
+    "WorkItemBucketBackupRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "s3.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "BucketBackupPolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetReplicationConfiguration",
+                "s3:ListBucket"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:s3:::",
+                      {
+                        "Ref": "RecordServiceS3Bucket"
+                      }
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "s3:GetObjectVersion",
+                "s3:GetObjectVersionAcl"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:s3:::",
+                      {
+                        "Ref": "RecordServiceS3Bucket"
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "s3:ReplicateObject",
+                "s3:ReplicateDelete"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:s3:::",
+                      {
+                        "Fn::Join": [
+                          "-",
+                          [
+                            {
+                              "Ref": "AWS::Region"
+                            },
+                            {
+                              "Ref": "AWS::StackName"
+                            },
+                            "replicationbucket"
+                          ]
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "PolicyName": "BucketBackupPolicy",
+        "Roles": [
+          {
+            "Ref": "WorkItemBucketBackupRole"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/test/resources/cft/AWS-S3-Object-Versioning-is-disabled/AWS-S3-Object-Versioning-is-disabled-positive.json
+++ b/src/test/resources/cft/AWS-S3-Object-Versioning-is-disabled/AWS-S3-Object-Versioning-is-disabled-positive.json
@@ -1,0 +1,210 @@
+{
+  "Resources": {
+    "RecordServiceS3Bucket": {
+      "Type": "AWS::S3::Bucket",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "ReplicationConfiguration": {
+          "Role": {
+            "Fn::GetAtt": [
+              "WorkItemBucketBackupRole",
+              "Arn"
+            ]
+          },
+          "Rules": [
+            {
+              "Destination": {
+                "Bucket": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:s3:::",
+                      {
+                        "Fn::Join": [
+                          "-",
+                          [
+                            {
+                              "Ref": "AWS::Region"
+                            },
+                            {
+                              "Ref": "AWS::StackName"
+                            },
+                            "replicationbucket"
+                          ]
+                        ]
+                      }
+                    ]
+                  ]
+                },
+                "StorageClass": "STANDARD"
+              },
+              "Id": "Backup",
+              "Prefix": "",
+              "Status": "Enabled"
+            }
+          ]
+        },
+        "VersioningConfiguration": {
+          "Status": "Suspended"
+        }
+      }
+    },
+    "RecordServiceS3Bucket2": {
+      "Type": "AWS::S3::Bucket",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "ReplicationConfiguration": {
+          "Role": {
+            "Fn::GetAtt": [
+              "WorkItemBucketBackupRole",
+              "Arn"
+            ]
+          },
+          "Rules": [
+            {
+              "Destination": {
+                "Bucket": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:s3:::",
+                      {
+                        "Fn::Join": [
+                          "-",
+                          [
+                            {
+                              "Ref": "AWS::Region"
+                            },
+                            {
+                              "Ref": "AWS::StackName"
+                            },
+                            "replicationbucket"
+                          ]
+                        ]
+                      }
+                    ]
+                  ]
+                },
+                "StorageClass": "STANDARD"
+              },
+              "Id": "Backup",
+              "Prefix": "",
+              "Status": "Enabled"
+            }
+          ]
+        },
+        "VersioningConfiguration": {
+          "Status": "Enabled"
+        }
+      }
+    },
+    "WorkItemBucketBackupRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "s3.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "BucketBackupPolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetReplicationConfiguration",
+                "s3:ListBucket"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:s3:::",
+                      {
+                        "Ref": "RecordServiceS3Bucket"
+                      }
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "s3:GetObjectVersion",
+                "s3:GetObjectVersionAcl"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:s3:::",
+                      {
+                        "Ref": "RecordServiceS3Bucket"
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
+                "s3:ReplicateObject",
+                "s3:ReplicateDelete"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:s3:::",
+                      {
+                        "Fn::Join": [
+                          "-",
+                          [
+                            {
+                              "Ref": "AWS::Region"
+                            },
+                            {
+                              "Ref": "AWS::StackName"
+                            },
+                            "replicationbucket"
+                          ]
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "PolicyName": "BucketBackupPolicy",
+        "Roles": [
+          {
+            "Ref": "WorkItemBucketBackupRole"
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixed rule for multiple S3 resources, and added pos / neg case

The only allowed states are [Enabled / Suspended ](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-versioningconfig.html), new rule looks for any Suspended Buckets (positive case).